### PR TITLE
added tensorflow requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sf_segmenter==0.0.2
 soundfile==0.11.0
 yt_dlp==2023.1.6
 demucs==4.0.0
+tensorflow


### PR DESCRIPTION
analysis was failing with a `module not found` error for tensorflow. unsure of what version is the preferred though

edit:

- i was getting an `illegal hardware instruction` after installing tensorflow this way
- i'm using an M1 mac and i noticed there's a [special tensorflow for apple silicon](https://developer.apple.com/metal/tensorflow-plugin/) so i went ahead and installed that
- this stopped giving me that error but now i got `module compiled against api version 0x10 but this version of numpy is 0xe` which seems to imply the [wrong numpy version](https://iq.opengenus.org/module-compiled-against-api-version-0x10-but-this-version-of-numpy-is-0xe/)

after these version fixes it started working (with a few warnings) but i didn't want to amend the PR since they apply only to apple silicon