### PR TITLE
fixed missing rubberband-cli in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-bullseye
 
 RUN apt update
-RUN apt install -y make automake gcc g++ python3-dev gfortran build-essential wget libsndfile1 ffmpeg
+RUN apt install -y rubberband-cli make automake gcc g++ python3-dev gfortran build-essential wget libsndfile1 ffmpeg
 
 RUN pip install --upgrade pip
 


### PR DESCRIPTION
Wasn't able to run with the `-t` option in docker because `rubberband-cli` wasn't installed 